### PR TITLE
test: fix the input for the action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
-          repo: Imamiland/${{matrix.repo}}
+          repository: Imamiland/${{matrix.repo}}
 
       - name: Check REUSE Compliance
         id: reuse_check


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflow to use the correct parameter for repository checkout.

### What changed?

Changed the `repo` parameter to `repository` in the `actions/checkout` step of the GitHub Actions workflow.

### How to test?

1. Run the GitHub Actions workflow.
2. Verify that the repository checkout step completes successfully.
3. Ensure that the subsequent steps in the workflow execute as expected.

### Why make this change?

The `actions/checkout` action uses `repository` as the correct parameter name for specifying the repository to check out. This change ensures that the workflow correctly references the desired repository, preventing potential errors in the checkout process and allowing the workflow to function as intended.