### PR TITLE
feat: add a simpler version of the action

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,5 +10,14 @@
         }
     ],
     "version": "0.2",
-    "words": ["mkdirp", "tsmerge", "Ali", "Sajid", "Imami", "pip", "pipx"]
+    "words": [
+        "mkdirp",
+        "tsmerge",
+        "Ali",
+        "Sajid",
+        "Imami",
+        "pip",
+        "pipx",
+        "threeal"
+    ]
 }

--- a/action.yaml
+++ b/action.yaml
@@ -18,26 +18,51 @@ inputs:
     required: false
     default: "${{ github.token }}"
 
-  # Optional argument to specify custom REUSE compliance checks or configurations
-  compliance_args:
-    description: "Optional arguments to pass to the REUSE tool."
-    required: false
-    default: ""
+  repo-path:
+    description: "Path to the repository where we run the helper tool"
+    required: true
+    default: "."
 
 # Define outputs to provide a summary of compliance
 outputs:
   compliance_status:
     description: "Returns 'compliant' or 'non-compliant' based on REUSE compliance check."
-    value: "true"
+    value: ${{ steps.output_status.compliance_status }}
   compliance_report:
     description: "Detailed output of the REUSE compliance check."
-    value: "{}"
+    value: ${{ steps.output_report.compliance_report }}
 
 # Define the action runs using composite
 runs:
   using: "composite"
   steps:
-    - name: Setup pipx
-      id: pipx_setup
+    - name: Check Environment Sanity
+      id: env_sanity
       shell: bash
-      run: pipx --version
+      run: |
+        echo "Checking that the environment is sane"
+        echo "Python Version: ${python --version}"
+        echo "Pipx Version: ${pipx --version}"
+        echo "jq Version: ${jq --version}"
+    - name: Setup REUSE helper tool
+      id: reuse_setup
+      uses: threeal/pipx-install-action@b0bf0add7d5aefda03a3d4e47d651df807889e10 # v1.0.0
+      with:
+        packages: reuse
+    - name: Run REUSE for linting
+      id: run_reuse
+      shell: bash
+      working-directory: ${{inputs.repo-path}}
+      run: reuse lint --json > reuse_results.json
+    - name: Output Compliance Report
+      id: output_report
+      shell: bash
+      working-directory: ${{inputs.repo-path}}
+      run: echo "compliance_report=${cat reuse_results.json}" >> $GITHUB_OUTPUT
+    - name: Output Compliance Status
+      id: output_status
+      shell: bash
+      working-directory: ${{inputs.repo-path}}
+      run: |
+        command_status=$(cat reuse_results.json | jq '.summary.compliant')
+        echo "compliance_status=$command_status" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### TL;DR

Updated the REUSE compliance action to include more comprehensive checks and outputs.

### What changed?

- Added "threeal" to the list of allowed words in `.cspell.json`.
- Introduced a new input `repo-path` to specify the repository location.
- Implemented environment sanity checks to verify Python, Pipx, and jq versions.
- Integrated the REUSE helper tool using the `threeal/pipx-install-action`.
- Added steps to run REUSE lint, generate a JSON report, and output compliance status and report.
- Updated the outputs to dynamically set the compliance status and report based on the REUSE lint results.

### How to test?

1. Use this action in a workflow, specifying the `repo-path` if different from the default.
2. Check the action outputs for `compliance_status` and `compliance_report`.
3. Verify that the REUSE lint is executed and generates a JSON report.
4. Confirm that the compliance status is correctly determined based on the REUSE results.

### Why make this change?

This update enhances the functionality and reliability of the REUSE compliance action. It provides more detailed outputs, allows for custom repository paths, and ensures the necessary tools are properly set up before running the compliance checks. These improvements will make it easier for users to integrate and interpret REUSE compliance results in their workflows.