### PR TITLE
test: update the test to take the repo-path argument

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,11 +28,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
+          path: main
+
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
           repository: Imamiland/${{matrix.repo}}
+          path: ${{matrix.repo}}
 
       - name: Check REUSE Compliance
         id: reuse_check
-        uses: ./
+        uses: ./main
+        with:
+          repo-path: ${{matrix.repo}}
 
       - name: Debug Output
-        run: echo ${{join(steps.reuse_check.outputs.compliance_report, '\n')}}
+        run: echo "${{ steps.reuse_check.outputs.compliance_report }}"

--- a/action.yaml
+++ b/action.yaml
@@ -41,9 +41,9 @@ runs:
       shell: bash
       run: |
         echo "Checking that the environment is sane"
-        echo "Python Version: ${python --version}"
-        echo "Pipx Version: ${pipx --version}"
-        echo "jq Version: ${jq --version}"
+        echo "Python Version: $( python --version )"
+        echo "Pipx Version: $( pipx --version )"
+        echo "jq Version: $( jq --version )"
     - name: Setup REUSE helper tool
       id: reuse_setup
       uses: threeal/pipx-install-action@b0bf0add7d5aefda03a3d4e47d651df807889e10 # v1.0.0
@@ -58,7 +58,7 @@ runs:
       id: output_report
       shell: bash
       working-directory: ${{inputs.repo-path}}
-      run: echo "compliance_report=${cat reuse_results.json}" >> $GITHUB_OUTPUT
+      run: echo "compliance_report=$( cat reuse_results.json )" >> $GITHUB_OUTPUT
     - name: Output Compliance Status
       id: output_status
       shell: bash


### PR DESCRIPTION
### TL;DR

Enhanced REUSE compliance check workflow and improved action execution.

### What changed?

- Updated the test workflow to checkout the main repository and the target repository separately.
- Modified the REUSE compliance check to use the main repository's action.
- Adjusted the debug output to properly display the compliance report.
- Improved environment sanity checks by correctly capturing command outputs.
- Updated the compliance report output to properly capture the contents of the results file.

### How to test?

1. Run the updated workflow against different repositories.
2. Verify that the REUSE compliance check executes correctly using the main repository's action.
3. Confirm that the debug output displays the compliance report accurately.
4. Check that the environment sanity checks show correct version information.
5. Ensure the compliance report is properly captured and available in the workflow outputs.

### Why make this change?

These changes improve the reliability and functionality of the REUSE compliance check action. By separating the checkout of the main repository and target repository, we ensure that the latest version of the action is always used. The improvements in output capturing and display enhance the visibility of the compliance results, making it easier to diagnose issues and verify compliance status.