### PR TITLE
fix: allow the reuse run step to continue regardless of error

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -54,6 +54,7 @@ runs:
       shell: bash
       working-directory: ${{inputs.repo-path}}
       run: reuse lint --json > reuse_results.json
+      continue-on-error: true
     - name: Output Compliance Report
       id: output_report
       shell: bash


### PR DESCRIPTION
### TL;DR

Added `continue-on-error: true` to the REUSE lint step in the GitHub Action.

### What changed?

The `action.yaml` file was modified to add the `continue-on-error: true` option to the "Run REUSE Lint" step. This allows the workflow to continue even if the REUSE lint command fails.

### How to test?

1. Run the GitHub Action on a repository with REUSE compliance issues.
2. Verify that the workflow continues to execute subsequent steps even if the REUSE lint step fails.
3. Check that the `reuse_results.json` file is still generated and available for the "Output Compliance Report" step.

### Why make this change?

This change ensures that the entire workflow doesn't fail due to REUSE compliance issues. It allows the action to complete and provide a compliance report, even when there are licensing or copyright problems in the repository. This approach gives users more flexibility in handling and reviewing REUSE compliance results without interrupting their CI/CD pipeline.