### PR TITLE
fix: correct the filename

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -60,7 +60,7 @@ runs:
       shell: bash
       working-directory: ${{inputs.repo-path}}
       run: |
-        compliance_report=$(cat reuse_results | jq @json )
+        compliance_report=$(cat reuse_results.json | jq @json )
         echo "compliance_report=$compliance_report" >> $GITHUB_OUTPUT
     - name: Output Compliance Status
       id: output_status

--- a/action.yaml
+++ b/action.yaml
@@ -53,7 +53,7 @@ runs:
       id: run_reuse
       shell: bash
       working-directory: ${{inputs.repo-path}}
-      run: reuse lint --json > reuse_results.json
+      run: reuse lint --json | tee reuse_results.json
       continue-on-error: true
     - name: Output Compliance Report
       id: output_report


### PR DESCRIPTION
### TL;DR

Updated the file path for reading compliance report results.

### What changed?

Modified the `action.yaml` file to read from `reuse_results.json` instead of `reuse_results` when generating the compliance report.

### How to test?

1. Run the action in a workflow
2. Verify that the compliance report is correctly generated from the `reuse_results.json` file
3. Ensure that the `compliance_report` output is properly set in the GitHub environment

### Why make this change?

This change ensures that the action reads from the correct JSON file containing the REUSE compliance results. The previous implementation may have been reading from an incorrect or non-existent file, potentially causing issues in the compliance reporting process.